### PR TITLE
feat: 🎸 为数据源引擎增加 module 入口, 以便支持 vite 和 snowpack 等现代构建工具

### DIFF
--- a/packages/datasource-engine/package.json
+++ b/packages/datasource-engine/package.json
@@ -6,13 +6,15 @@
   "typings": "dist/index.d.ts",
   "files": [
     "dist",
+    "es",
     "src",
     "interpret*",
     "runtime*"
   ],
   "scripts": {
     "clean": "rm -rf dist",
-    "build": "npm run clean && tsc ",
+    "build": "npm run clean && tsc && npm run build:es",
+    "build:es": "tsc --target es5 --module es6 --outDir es",
     "test": "ava",
     "prepublishOnly": "npm run build"
   },


### PR DESCRIPTION
如题，目前的数据源引擎的包的入口中缺少 module 入口，在 vite 和 snowpack 等现代构建工具中使用的时候会因此遇到一些问题，故补充下。