### PR TITLE
fix: 修改fetch请求返回值数据格式，避免预览展示数据不一致

### DIFF
--- a/packages/datasource-fetch-handler/src/index.ts
+++ b/packages/datasource-fetch-handler/src/index.ts
@@ -16,6 +16,6 @@ export function createFetchHandler(config?: Record<string, unknown>) {
       ...config,
     };
     const response = await request(requestConfig);
-    return response;
+    return response.data;
   };
 }


### PR DESCRIPTION
画布与预览请求返回值数据格式不一致，导致画布显示真实数据，预览数据不展示

<img width="683" alt="CleanShot-2022-06-25-02 18 44@2x" src="https://user-images.githubusercontent.com/37948383/175625545-7a3c0343-420f-45c4-8c2a-3d487580a14e.png">



<img width="703" alt="CleanShot-2022-06-25-02 18 23@2x" src="https://user-images.githubusercontent.com/37948383/175625053-5cb18ddb-6463-451b-b445-f6ca7de4e56b.png">
