### PR TITLE
fix: 修改fetchOptios.params数组类型转为对象问题

### DIFF
--- a/packages/datasource-engine/src/core/RuntimeDataSourceItem.ts
+++ b/packages/datasource-engine/src/core/RuntimeDataSourceItem.ts
@@ -92,7 +92,12 @@ class RuntimeDataSourceItem<TParams extends Record<string, unknown> = Record<str
 
     // 如果load存在参数则采取合并的策略合并参数，合并后再一起参与shouldFetch，willFetch的计算
     if (params) {
-      fetchOptions.params = merge(fetchOptions.params, params);
+      // 由于直接传入数组会导致merge合并时把数组强转成对象导致接口调用失败
+      if (Array.isArray(params)) {
+        fetchOptions.params = params;
+      } else {
+        fetchOptions.params = merge(fetchOptions.params, params);
+      }
     }
 
     if (this._dataSourceConfig.shouldFetch) {


### PR DESCRIPTION
![image](https://github.com/alibaba/lowcode-datasource/assets/23305067/5941dc03-eae7-4b35-adc7-94ca7d7eb45b)
如图，fetchOptions的params在merge会强制把数组类型转为对象，接口参数会错误。
这里把merge加一层判断，区分有无数组情况