### PR TITLE
fix: 🐛 Remove unused JSExpression and JSFunction functions

### DIFF
--- a/packages/datasource-types/src/value-type.ts
+++ b/packages/datasource-types/src/value-type.ts
@@ -81,11 +81,3 @@ export type CompositeArray = CompositeValue[];
 export interface CompositeObject {
   [key: string]: CompositeValue;
 }
-
-export function isJSExpression(data: any): data is JSExpression {
-  return data && data.type === 'JSExpression';
-}
-
-export function isJSFunction(x: any): x is JSFunction {
-  return typeof x === 'object' && x && x.type === 'JSFunction';
-}


### PR DESCRIPTION
JSExpression and JSFunction are exported in @lowcode-types, so exporting them here will cause conflicts